### PR TITLE
Fix loading qagame so on GNU/Linux

### DIFF
--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -183,7 +183,7 @@ This is the only way control passes into the module.
 This must be the very first function compiled into the .q3vm file
 ================
 */
-intptr_t vmMain( int command, int arg0, int arg1, int arg2 ) {
+DLLEXPORT intptr_t vmMain( int command, int arg0, int arg1, int arg2 ) {
 	switch ( command ) {
 	case GAME_INIT:
 		G_InitGame( arg0, arg1, arg2 );


### PR DESCRIPTION
qagamex86_64.so doesn't load on GNU/Linux due to vmMain not being exported.