### PR TITLE
CGAME: fix for PW_REGEN powerup prediction (playing pain sounds).

### DIFF
--- a/code/cgame/cg_predict.c
+++ b/code/cgame/cg_predict.c
@@ -618,9 +618,10 @@ static void CG_CheckTimers( void ) {
 	if ( cg.predictedPlayerState.stats[STAT_HEALTH] <= 0 )
 		return;
 
+	cg.timeResidual += 1000;
 	// periodic tasks
 	if ( cg.timeResidual && cg.predictedPlayerState.commandTime >= cg.timeResidual && !cg.thisFrameTeleport ) {
-		cg.timeResidual += 1000;
+		cg.timeResidual -= 1000;
 		if ( cg.predictedPlayerState.powerups[ PW_REGEN ] ) {
 			int maxhealth = cg.predictedPlayerState.stats[ STAT_MAX_HEALTH ];
 			if ( cg.predictedPlayerState.stats[ STAT_HEALTH ] < maxhealth ) {


### PR DESCRIPTION
BUG: sometimes the player's pain sound is played when the player's health increases (e.g.: holding the Regeneration powerup).
In this case every second the powerup increases the health of a player a pain sound is played additionally to the powerup regeneration sound. A while ago I talked about this issue here: https://github.com/ec-/Quake3e/issues/18
Anyways, this issue is really hard to reproduce because it only happens very rare.

BUGFIX: I have been playing around with the code for over a year and have never figured out what is causing the problem, nor have I found a solution.
Well, now I found out that changen how cg.timeResidual is set seems to fix the issue.
To be honest I don't understand why this will fix the issue. I simply borrowed the code from 'ClientTimerActions' (in g_active.c).

NOTE: I played many matches using this 'bugfix' and it seem to work well. If you want apply the PR I highly recommend to check the changes twice, because I don't really understand the code, and potential consequences.

