### PR TITLE
Don't use uninitialized ps from BotAI_GetClientState.

### DIFF
--- a/code/game/ai_chat.c
+++ b/code/game/ai_chat.c
@@ -80,8 +80,7 @@ int BotIsFirstInRankings(bot_state_t *bs) {
 		//skip spectators
 		if (atoi(Info_ValueForKey(buf, "t")) == TEAM_SPECTATOR) continue;
 		//
-		BotAI_GetClientState(i, &ps);
-		if (score < ps.persistant[PERS_SCORE]) return qfalse;
+		if (BotAI_GetClientState(i, &ps) && score < ps.persistant[PERS_SCORE]) return qfalse;
 	}
 	return qtrue;
 }
@@ -104,8 +103,7 @@ int BotIsLastInRankings(bot_state_t *bs) {
 		//skip spectators
 		if (atoi(Info_ValueForKey(buf, "t")) == TEAM_SPECTATOR) continue;
 		//
-		BotAI_GetClientState(i, &ps);
-		if (score > ps.persistant[PERS_SCORE]) return qfalse;
+		if (BotAI_GetClientState(i, &ps) && score > ps.persistant[PERS_SCORE]) return qfalse;
 	}
 	return qtrue;
 }
@@ -130,8 +128,7 @@ char *BotFirstClientInRankings(void) {
 		//skip spectators
 		if (atoi(Info_ValueForKey(buf, "t")) == TEAM_SPECTATOR) continue;
 		//
-		BotAI_GetClientState(i, &ps);
-		if (ps.persistant[PERS_SCORE] > bestscore) {
+		if (BotAI_GetClientState(i, &ps) && ps.persistant[PERS_SCORE] > bestscore) {
 			bestscore = ps.persistant[PERS_SCORE];
 			bestclient = i;
 		}
@@ -161,8 +158,7 @@ char *BotLastClientInRankings(void) {
 		//skip spectators
 		if (atoi(Info_ValueForKey(buf, "t")) == TEAM_SPECTATOR) continue;
 		//
-		BotAI_GetClientState(i, &ps);
-		if (ps.persistant[PERS_SCORE] < worstscore) {
+		if (BotAI_GetClientState(i, &ps) && ps.persistant[PERS_SCORE] < worstscore) {
 			worstscore = ps.persistant[PERS_SCORE];
 			bestclient = i;
 		}

--- a/code/game/ai_dmq3.c
+++ b/code/game/ai_dmq3.c
@@ -189,7 +189,10 @@ qboolean EntityIsDead(aas_entityinfo_t *entinfo) {
 
 	if (entinfo->number >= 0 && entinfo->number < MAX_CLIENTS) {
 		//retrieve the current client state
-		BotAI_GetClientState( entinfo->number, &ps );
+		if (!BotAI_GetClientState( entinfo->number, &ps )) {
+			return qfalse;
+		}
+
 		if (ps.pm_type != PM_NORMAL) return qtrue;
 	}
 	return qfalse;

--- a/code/game/ai_main.c
+++ b/code/game/ai_main.c
@@ -981,8 +981,10 @@ int BotAI(int client, float thinktime) {
 	}
 
 	//retrieve the current client state
-	BotAI_GetClientState( client, &bs->cur_ps );
-
+	if (!BotAI_GetClientState( client, &bs->cur_ps )) {
+		BotAI_Print(PRT_FATAL, "BotAI: failed to get player state for player %d\n", client);
+		return qfalse;
+	}
 	//retrieve any waiting server commands
 	while( trap_BotGetServerCommand(client, buf, sizeof(buf)) ) {
 		//have buf point to the command and args to the command arguments

--- a/code/game/ai_team.c
+++ b/code/game/ai_team.c
@@ -90,8 +90,12 @@ int BotClientTravelTimeToGoal(int client, bot_goal_t *goal) {
 	playerState_t ps;
 	int areanum;
 
-	BotAI_GetClientState(client, &ps);
-	areanum = BotPointAreaNum(ps.origin);
+	if (BotAI_GetClientState(client, &ps)) {
+		areanum = BotPointAreaNum(ps.origin);
+	} else {
+		areanum = 0;
+	}
+
 	if (!areanum) return 1;
 	return trap_AAS_AreaTravelTimeToGoalArea(areanum, ps.origin, goal->areanum, TFL_DEFAULT);
 }


### PR DESCRIPTION
I'll start a series of pull requests with bugfixes from ioquake3, not implemented in baseq3 until now.

CHANGES: Don't use uninitialized ps from BotAI_GetClientState.
NOTES: https://github.com/ioquake/ioq3/commit/6e340f9a5b185b58b80063655cd4cffd463b707c
