### PR TITLE
Fix lightning gun weapon number zeroed when sending weapon info to EV_MISSILE_MISS event

### DIFF
--- a/code/game/g_weapon.c
+++ b/code/game/g_weapon.c
@@ -708,6 +708,7 @@ void Weapon_LightningFire( gentity_t *ent ) {
 		} else if ( !( tr.surfaceFlags & SURF_NOIMPACT ) ) {
 			tent = G_TempEntity( tr.endpos, EV_MISSILE_MISS );
 			tent->s.eventParm = DirToByte( tr.plane.normal );
+			tent->s.weapon = ent->s.weapon;
 		}
 
 		break;


### PR DESCRIPTION
This forgotten detail from id Software has been unfixed for years and years.
So, that means lightning gun sounds and effects don't play while the weapon number is always 0.
That can be reproduced and debugged writing these lines on `cgame/cg_weapons.c` in line ~2054:
```c
	Com_Printf( "what weapon I am holding? answer: %d\n", weapon );
	Com_Printf( "WP_GAUNTLET: %d\n", WP_GAUNTLET );
	Com_Printf( "WP_MACHINEGUN: %d\n", WP_MACHINEGUN );
	Com_Printf( "WP_SHOTGUN: %d\n", WP_SHOTGUN );
	Com_Printf( "WP_GRENADE_LAUNCHER: %d\n", WP_GRENADE_LAUNCHER );
	Com_Printf( "WP_ROCKET_LAUNCHER: %d\n", WP_ROCKET_LAUNCHER );
	Com_Printf( "WP_LIGHTNING: %d\n", WP_LIGHTNING );
	Com_Printf( "WP_RAILGUN: %d\n", WP_RAILGUN );
	Com_Printf( "WP_PLASMAGUN: %d\n", WP_PLASMAGUN );
	Com_Printf( "WP_BFG: %d\n", WP_BFG );
```

Compile, run the game, get the lightning gun weapon, use it and shoot no matter where, it will print the log in the console.

That's what happens in the console log:
- Before/Original:
```
what weapon I am holding? answer: 0
WP_GAUNTLET: 1
WP_MACHINEGUN: 2
WP_SHOTGUN: 3
WP_GRENADE_LAUNCHER: 4
WP_ROCKET_LAUNCHER: 5
WP_LIGTHNING: 6
WP_RAILGUN: 7
WP_PLASMAGUN: 8
WP_BFG: 9
```

- Fixed:
```
what weapon I am holding? answer: 6
WP_GAUNTLET: 1
WP_MACHINEGUN: 2
WP_SHOTGUN: 3
WP_GRENADE_LAUNCHER: 4
WP_ROCKET_LAUNCHER: 5
WP_LIGTHNING: 6
WP_RAILGUN: 7
WP_PLASMAGUN: 8
WP_BFG: 9
```