### PR TITLE
Small fix "warning: implicit declaration of function ‘atof’" on modulus.c external tool

### DIFF
--- a/code/cgame/modulus.c
+++ b/code/cgame/modulus.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <math.h>
 
 #define PI 3.1415926535897932384


### PR DESCRIPTION
Fixes the warning displaying in the console/terminal:
```
main.c: In function ‘main’:
main.c:18:26: warning: implicit declaration of function ‘atof’ [-Wimplicit-function-declaration]
   18 |                 divide = atof( argv[1] );
      |                          ^~~~
```