### PR TITLE
Fix ED_vsprintf crash on Linux (#3)

### DIFF
--- a/code/game/bg_misc.c
+++ b/code/game/bg_misc.c
@@ -2335,7 +2335,7 @@ reswitch:
 			width = va_arg( ap, int );
 			goto rflag;
 		case 'c':
-			*buf_p = va_arg( ap, char ); buf_p++;
+			*buf_p = (char)va_arg( ap, int ); buf_p++;
 			break;
 		case 'd':
 		case 'i':
@@ -2355,7 +2355,7 @@ reswitch:
 			flags |= REDUCE;
 			goto rflag;
 		default:
-			*buf_p = va_arg( ap, char ); buf_p++;
+			*buf_p = (char)va_arg( ap, int ); buf_p++;
 			break;
 		} // switch ( ch )
 	} // while ( qtrue )


### PR DESCRIPTION
Fixes the crash of this function on Linux.
The crash leaded to `va_list` misalignment to `ap` parameter. The variadic arguments smaller than `int` are promoted, so retrieving them as `char` reads the wrong size, corrupting the argument pointer.