### PR TITLE
Fix grappling hook visual muzzle position, now it's tagged correctly to 'tag_flash' and fix the missing grappling trail shader

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Unofficial Quake III Arena gamecode patch
  * fixed in-game crosshair proportions
  * fixed UI mouse sensitivity for high-resolution
  * fixed server browser + faster scanning
+ * fixed grappling hook muzzle position visuals
  * new demo UI (subfolders,filtering,sorting)
  * updated serverinfo UI
  * map rotation system

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -152,6 +152,8 @@ typedef struct {
 	qboolean		painIgnore;
 	int				lightningFiring;
 
+	vec3_t			muzzleOrigin;
+
 	// railgun trail spawning
 	vec3_t			railgunImpact;
 	qboolean		railgunFlash;


### PR DESCRIPTION
Fixes a `FIXME` task in `CG_GrappleTrail` from id Software, which was left since the first Q3 version release.
Also fixes the missing shader of grappling hook trail.