### PR TITLE
Fix adding `Menu_Reset` to right include file

### DIFF
--- a/code/cgame/cg_consolecmds.c
+++ b/code/cgame/cg_consolecmds.c
@@ -113,7 +113,6 @@ static void CG_ScoresUp_f( void ) {
 
 #ifdef MISSIONPACK
 extern menuDef_t *menuScoreboard;
-void Menu_Reset( void );			// FIXME: add to right include file
 
 static void CG_LoadHud_f( void) {
   char buff[1024];

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -1440,6 +1440,9 @@ void CG_ScoreboardClick( void );
 //
 qboolean CG_ConsoleCommand( void );
 void CG_InitConsoleCommands( void );
+#ifdef MISSIONPACK
+void Menu_Reset( void );
+#endif
 
 //
 // cg_servercmds.c


### PR DESCRIPTION
Completes a `FIXME` task from `Menu_Reset` since they didn't add correctly to the include file. (Why would they leave this simple line?)