### PR TITLE
Refactor `ED_vsprintf` to `Q_vsprintf` and remove unnecessary `#ifdef MISSIONPACK` when it's already inside the code part

### DIFF
--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -224,7 +224,7 @@ void QDECL CG_Printf( const char *msg, ... ) {
 	char		text[1024];
 
 	va_start (argptr, msg);
-	ED_vsprintf (text, msg, argptr);
+	Q_vsprintf (text, msg, argptr);
 	va_end (argptr);
 
 	trap_Print( text );
@@ -235,7 +235,7 @@ void QDECL CG_Error( const char *msg, ... ) {
 	char		text[1024];
 
 	va_start (argptr, msg);
-	ED_vsprintf (text, msg, argptr);
+	Q_vsprintf (text, msg, argptr);
 	va_end (argptr);
 
 	trap_Error( text );
@@ -249,7 +249,7 @@ void QDECL Com_Error( int level, const char *error, ... ) {
 	char		text[1024];
 
 	va_start (argptr, error);
-	ED_vsprintf (text, error, argptr);
+	Q_vsprintf (text, error, argptr);
 	va_end (argptr);
 
 	trap_Error( text );
@@ -260,7 +260,7 @@ void QDECL Com_Printf( const char *msg, ... ) {
 	char		text[1024];
 
 	va_start (argptr, msg);
-	ED_vsprintf (text, msg, argptr);
+	Q_vsprintf (text, msg, argptr);
 	va_end (argptr);
 
 	trap_Print( text );
@@ -1004,6 +1004,7 @@ void CG_StartMusic( void ) {
 
 	trap_S_StartBackgroundTrack( parm1, parm2 );
 }
+
 #ifdef MISSIONPACK
 char *CG_GetMenuBuffer(const char *filename) {
 	int	len;
@@ -1508,18 +1509,14 @@ static void CG_FeederSelection(float feederID, int index) {
 		cg.selectedScore = index;
 	}
 }
-#endif
 
-#ifdef MISSIONPACK
 static float CG_Cvar_Get(const char *cvar) {
 	char buff[128];
 	memset(buff, 0, sizeof(buff));
 	trap_Cvar_VariableStringBuffer(cvar, buff, sizeof(buff));
 	return atof(buff);
 }
-#endif
 
-#ifdef MISSIONPACK
 void CG_Text_PaintWithCursor(float x, float y, float scale, vec4_t color, const char *text, int cursorPos, char cursor, int limit, int style) {
 	CG_Text_Paint(x, y, scale, color, text, 0, limit, style);
 }

--- a/code/game/ai_main.c
+++ b/code/game/ai_main.c
@@ -77,7 +77,7 @@ void QDECL BotAI_Print( int type, const char *fmt, ... ) {
 	va_list ap;
 
 	va_start(ap, fmt);
-	ED_vsprintf(str, fmt, ap);
+	Q_vsprintf(str, fmt, ap);
 	va_end(ap);
 
 	switch(type) {

--- a/code/game/bg_lib.h
+++ b/code/game/bg_lib.h
@@ -47,7 +47,7 @@ int toupper( int c );
 double atof( const char *string );
 int atoi( const char *string );
 
-int ED_vsprintf( char *buffer, const char *fmt, va_list argptr );
+int Q_vsprintf( char *buffer, const char *fmt, va_list argptr );
 int Q_sscanf( const char *buffer, const char *fmt, ... );
 
 // Memory functions

--- a/code/game/bg_misc.c
+++ b/code/game/bg_misc.c
@@ -2154,7 +2154,7 @@ static void AddString( char **buf_p, const char *string, int width, int prec ) {
 
 
 /*
-ED_vsprintf
+Q_vsprintf
 
 I'm not going to support a bunch of the more arcane stuff in here
 just to keep it simpler.  For example, the '$' is not
@@ -2163,7 +2163,7 @@ parse and ignore formats we don't support.
 
 returns: number of char written without ending '\0'
 */
-int ED_vsprintf( char *buffer, const char *fmt, va_list ap ) {
+int Q_vsprintf( char *buffer, const char *fmt, va_list ap ) {
 	char	*buf_p;
 	char	ch;
 	int		flags;
@@ -2269,7 +2269,7 @@ int BG_sprintf( char *buf, const char *format, ... )
 	int len;
 	va_list	argptr;
 	va_start( argptr, format );
-	len = ED_vsprintf( buf, format, argptr );
+	len = Q_vsprintf( buf, format, argptr );
 	va_end( argptr );
 	return len;
 }

--- a/code/game/bg_public.h
+++ b/code/game/bg_public.h
@@ -644,7 +644,7 @@ qboolean	BG_PlayerTouchesItem( playerState_t *ps, entityState_t *item, int atTim
 // custom functions
 
 int BG_sprintf( char *buf, const char *format, ... );
-int ED_vsprintf( char *buffer, const char *fmt, va_list argptr );
+int Q_vsprintf( char *buffer, const char *fmt, va_list argptr );
 
 char *Q_stristr( const char * str1, const char * str2 );
 

--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -102,7 +102,7 @@ void QDECL G_Printf( const char *fmt, ... ) {
 	int			len;
 
 	va_start( argptr, fmt );
-	len = ED_vsprintf( text, fmt, argptr );
+	len = Q_vsprintf( text, fmt, argptr );
 	va_end( argptr );
 
 	text[4095] = '\0'; // truncate to 1.32b/c max print buffer size
@@ -128,7 +128,7 @@ void QDECL G_Error( const char *fmt, ... ) {
 	char		text[1024];
 
 	va_start( argptr, fmt );
-	ED_vsprintf( text, fmt, argptr );
+	Q_vsprintf( text, fmt, argptr );
 	va_end( argptr );
 
 	trap_Error( text );
@@ -534,7 +534,7 @@ void QDECL Com_Error( int level, const char *fmt, ... ) {
 	char		text[4096];
 
 	va_start( argptr, fmt );
-	ED_vsprintf( text, fmt, argptr );
+	Q_vsprintf( text, fmt, argptr );
 	va_end( argptr );
 
 	trap_Error( text );
@@ -546,7 +546,7 @@ void QDECL Com_Printf( const char *fmt, ... ) {
 	char		text[4096];
 
 	va_start( argptr, fmt );
-	ED_vsprintf( text, fmt, argptr );
+	Q_vsprintf( text, fmt, argptr );
 	va_end( argptr );
 
 	trap_Print( text );
@@ -1108,7 +1108,7 @@ void QDECL G_LogPrintf( const char *fmt, ... ) {
 	len = Com_sprintf( string, sizeof( string ), "%3i:%02i.%i ", min, sec, tsec );
 
 	va_start( argptr, fmt );
-	ED_vsprintf( string + len, fmt,argptr );
+	Q_vsprintf( string + len, fmt,argptr );
 	va_end( argptr );
 
 	n = (int)strlen( string );

--- a/code/game/g_team.c
+++ b/code/game/g_team.c
@@ -93,7 +93,7 @@ void QDECL PrintMsg( gentity_t *ent, const char *fmt, ... ) {
 	char		*p;
 	
 	va_start (argptr,fmt);
-	if ( ED_vsprintf( msg, fmt, argptr ) >= sizeof( msg ) ) {
+	if ( Q_vsprintf( msg, fmt, argptr ) >= sizeof( msg ) ) {
 		G_Error ( "PrintMsg overrun" );
 	}
 	va_end (argptr);

--- a/code/game/q_shared.c
+++ b/code/game/q_shared.c
@@ -120,7 +120,7 @@ char *COM_Parse( char **data_p )
 }
 
 
-extern int ED_vsprintf( char *buffer, const char *fmt, va_list argptr );
+extern int Q_vsprintf( char *buffer, const char *fmt, va_list argptr );
 
 
 void COM_ParseError( char *format, ... )
@@ -129,7 +129,7 @@ void COM_ParseError( char *format, ... )
 	static char string[4096];
 
 	va_start (argptr, format);
-	ED_vsprintf (string, format, argptr);
+	Q_vsprintf (string, format, argptr);
 	va_end (argptr);
 
 	Com_Printf("ERROR: %s, line %d: %s\n", com_parsename, com_lines, string);
@@ -142,7 +142,7 @@ void COM_ParseWarning( char *format, ... )
 	static char string[4096];
 
 	va_start (argptr, format);
-	ED_vsprintf (string, format, argptr);
+	Q_vsprintf (string, format, argptr);
 	va_end (argptr);
 
 	Com_Printf("WARNING: %s, line %d: %s\n", com_parsename, com_lines, string);
@@ -982,7 +982,7 @@ int QDECL Com_sprintf( char *dest, int size, const char *fmt, ... ) {
 	int len;
 
 	va_start( argptr, fmt );
-	len = ED_vsprintf( dest, fmt, argptr );
+	len = Q_vsprintf( dest, fmt, argptr );
 	va_end( argptr );
 
 	if ( len >= size ) {
@@ -1013,7 +1013,7 @@ char * QDECL va( const char *format, ... )
 	index ^= 1;
 
 	va_start( argptr, format );
-	ED_vsprintf( buf, format, argptr );
+	Q_vsprintf( buf, format, argptr );
 	va_end( argptr );
 
 	return buf;

--- a/code/q3_ui/ui_atoms.c
+++ b/code/q3_ui/ui_atoms.c
@@ -18,7 +18,7 @@ void QDECL Com_Error( int level, const char *fmt, ... ) {
 	char		text[2048];
 
 	va_start( argptr, fmt );
-	ED_vsprintf( text, fmt, argptr );
+	Q_vsprintf( text, fmt, argptr );
 	va_end (argptr);
 
 	trap_Error( text );
@@ -29,7 +29,7 @@ void QDECL Com_Printf( const char *fmt, ... ) {
 	char		text[2048];
 
 	va_start( argptr, fmt );
-	ED_vsprintf( text, fmt, argptr );
+	Q_vsprintf( text, fmt, argptr );
 	va_end (argptr);
 
 	trap_Print( text );


### PR DESCRIPTION
Shouldn't this function be named as `Q_vsprintf`? Sounds better.
On the other hand, I noticed that `#ifdef MISSIONPACK` block was declared three times in the same part, so it's removed to be declared once.