### PR TITLE
Add .gitattributes, .gitignore and GitHub build workflows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,103 @@
+name: Build
+on: [push]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+        arch: [x86, x86_64]
+        include:
+          # Windows
+          - os: windows-latest
+            arch: x86
+            platform: windows
+          - os: windows-latest
+            arch: x86_64
+            platform: windows
+          # Linux
+          - os: ubuntu-latest
+            arch: x86
+            platform: linux
+          - os: ubuntu-latest
+            arch: x86_64
+            platform: linux
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Install dependencies
+      if: ${{ matrix.os != 'windows-latest' }}
+      shell: bash
+      run: |
+        sudo apt-get update # && sudo apt-get upgrade -y
+        sudo apt-get install -y build-essential libc6-dev-i386 g++-multilib gcc-mingw-w64 p7zip-full
+
+    - name: Build for ${{ matrix.os }} ${{ matrix.arch }}
+      shell: bash
+      run: |
+        if [ "${{ matrix.os }}" == "windows-latest" ]; then
+          # Windows build steps
+          cd build/win32-qvm
+          ./compile.bat
+        else
+          # Linux build steps
+          cd build/linux
+          make -j8 release ARCH="${{ matrix.arch }}"
+          make -j8 debug ARCH="${{ matrix.arch }}"
+
+          # compiles DLL behaving like MINGW:
+          make -j8 release PLATFORM=mingw64 ARCH="${{ matrix.arch }}"
+          make -j8 debug PLATFORM=mingw64 ARCH="${{ matrix.arch }}"
+
+          # compiling QVMs
+          cd ../../build/linux-qvm
+          sudo chmod 777 tools/* # make all of them executable
+          make
+        fi
+      env:
+        ARCHIVE: 1
+
+    - name: Store QVM artifacts
+      # store only with Linux x86_64
+      if: ${{ matrix.os != 'windows-latest' && matrix.arch != 'x86' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: QVMs
+        path: |
+          build/linux-qvm/*.pk3
+        if-no-files-found: error
+        retention-days: 5
+
+    - name: Store Linux ${{ matrix.arch }} .so artifacts
+      if: ${{ matrix.os != 'windows-latest' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.platform }}-${{ matrix.arch }}
+        path: |
+          build/linux/build/release-${{ matrix.platform }}-${{ matrix.arch }}/baseq3a/*.so
+          build/linux/build/debug-${{ matrix.platform }}-${{ matrix.arch }}/baseq3a/*.so
+        if-no-files-found: error
+        retention-days: 5
+
+    - name: Store Windows ${{ matrix.arch }} DLL artifacts (compiled on Linux)
+      if: ${{ matrix.os != 'windows-latest' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: windows-${{ matrix.arch }}
+        path: |
+          build/linux/build/release-mingw64-${{ matrix.arch }}/baseq3a/*.dll
+          build/linux/build/debug-mingw64-${{ matrix.arch }}/baseq3a/*.dll
+        if-no-files-found: error
+        retention-days: 5
+
+    - name: Publish a release
+      uses: softprops/action-gh-release@v2
+      if: startsWith(github.ref, 'refs/tags/')
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        files: |
+          *.pk3
+          *.dll
+          *.so

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+build/linux/build*
+
+build/linux-qvm/vm*
+build/linux-qvm/*.pk3
+
+build/win32-msvc/.vs
+build/win32-msvc/Backup
+build/win32-msvc/Win32
+build/win32-msvc/Win64
+build/win32-msvc/baseq3e.sln
+build/win32-msvc/*.vcxproj
+build/win32-msvc/*.vcxproj.filters
+build/win32-msvc/*.htm
+
+build/win32-qvm/vm*
+build/win32-qvm/*.pk3
+build/win32-qvm/*.pk3.tmp


### PR DESCRIPTION
- `.gitattributes`: Keeps LF line-endings for each file every time some of them is opened. It's troublesome when it's being opened in another editor changing to CRLF without noticing.

- `.gitignore`: Ignores all builds. Not everybody adds the source code and doc files specifically, if somebody adds all, it would lead some mistake adding compiled files when only the source code and some docs must be present every time they commit.

- `.github/workflows/build.yml`: Every time a commit is pushed on GitHub, go to Actions >> select the commited run and artifacts will be available if the build went ok! So, you can download any artifact available inside this commited run.
See any jobs of them to analyze what happens (you can see the run logs when you're logged in).

The artifacts are retained every 5 days to avoid cache overloads, if you want you can change the number of retention days within:
```yaml
retention-days: 5
```