### PR TITLE
fix: shotgun not gibbing unless aiming at feet

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Unofficial Quake III Arena gamecode patch
  * fixed spawn system
  * fixed in-game crosshair proportions
  * fixed UI mouse sensitivity for high-resolution
- * fixed shotgun not gibbing unless aiming at the feet (`g_shotgunGibFix` CVAR)
+ * fixed shotgun not gibbing unless aiming at the feet
  * fixed server browser + faster scanning
  * fixed grappling hook muzzle position visuals
  * new demo UI (subfolders,filtering,sorting)

--- a/code/game/g_combat.c
+++ b/code/game/g_combat.c
@@ -583,26 +583,25 @@ void player_die( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int
 
 	self->s.loopSound = 0;
 
-	if (!g_shotgunGibFix.integer) {
-		// Executing this line causes a bug where the shotgun doesn't gib
-		// unless you aim at the feet.
-		// See https://github.com/ioquake/ioq3/issues/794.
-		//
-		// Note that without this line (when `g_shotgunGibFix` is enabled),
-		// when shooting at two players standing
-		// behind each other, the second target will take less damage,
-		// because the dead body of the first player will absorb the pellets
-		// until it gets gibbed (that is, up to 4 pellets,
-		// see `GIB_HEALTH` and `DEFAULT_SHOTGUN_DAMAGE`).
-		//
-		// The purpose and the effect of this line is not entirely clear.
-		// Maybe it's to transition the player hitbox
-		// into the "lying down dead" state, make it shorter.
-		// But this is already handled in `PM_CheckDuck`,
-		// so maybe it's just leftover code.
-		// So let's keep this line for now, but put behind a cvar.
-		self->r.maxs[2] = -8;
-	}
+	// The below line has been commented out in
+	// https://github.com/ec-/baseq3a/pull/49.
+	// Executing this line causes a bug where the shotgun doesn't gib
+	// unless you aim at the feet.
+	// See https://github.com/ioquake/ioq3/issues/794.
+	//
+	// Note that without this line, when shooting at two players standing
+	// behind each other, the second target will take less damage,
+	// because the dead body of the first player will absorb the pellets
+	// until it gets gibbed (that is, up to 4 pellets,
+	// see `GIB_HEALTH` and `DEFAULT_SHOTGUN_DAMAGE`).
+	//
+	// The purpose and the effect of this line is not entirely clear.
+	// Maybe it's to transition the player hitbox
+	// into the "lying down dead" state, make it shorter.
+	// But this is already handled in `PM_CheckDuck`,
+	// so maybe it's just leftover code.
+	//
+	// self->r.maxs[2] = -8;
 
 	// don't allow respawn until the death anim is done
 	// g_forcerespawn may force spawning at some later time

--- a/code/game/g_cvar.h
+++ b/code/game/g_cvar.h
@@ -62,7 +62,6 @@ G_CVAR( g_debugDamage, "g_debugDamage", "0", 0, 0, qfalse, qfalse )
 G_CVAR( g_debugAlloc, "g_debugAlloc", "0", 0, 0, qfalse, qfalse )
 G_CVAR( g_motd, "g_motd", "", 0, 0, qfalse, qfalse )
 G_CVAR( g_blood, "com_blood", "1", 0, 0, qfalse, qfalse )
-G_CVAR( g_shotgunGibFix, "g_shotgunGibFix", "1", CVAR_ARCHIVE, 0, qfalse, qfalse )
 
 G_CVAR( g_podiumDist, "g_podiumDist", "80", 0, 0, qfalse, qfalse )
 G_CVAR( g_podiumDrop, "g_podiumDrop", "70", 0, 0, qfalse, qfalse )


### PR DESCRIPTION
Original ioquake issue: https://github.com/ioquake/ioq3/issues/794.
Original (rejected) MR: https://github.com/ioquake/ioq3/pull/795.

Unlike the original MR, this suggests to enable the fix by default (which I'm OK with changing).

I have checked that this works by using the built `pak8a.pk3`.