### PR TITLE
improvement: allow multiple bounce marks and bounce sounds (gibs)

### DIFF
--- a/code/cgame/cg_cvar.h
+++ b/code/cgame/cg_cvar.h
@@ -41,6 +41,7 @@ CG_CVAR( cg_simpleItems, "cg_simpleItems", "0", CVAR_ARCHIVE )
 CG_CVAR( cg_addMarks, "cg_marks", "1", CVAR_ARCHIVE )
 // Note that ~290 corresponds to a free fall with no bounce from player height.
 CG_CVAR( cg_bounceMarksMinImpactSpeed, "cg_bounceMarksMinImpactSpeed", "350", CVAR_ARCHIVE )
+CG_CVAR( cg_bounceSoundMinImpactSpeed, "cg_bounceSoundMinImpactSpeed", "450", CVAR_ARCHIVE )
 CG_CVAR( cg_lagometer, "cg_lagometer", "1", CVAR_ARCHIVE )
 CG_CVAR( cg_railTrailTime, "cg_railTrailTime", "400", CVAR_ARCHIVE  )
 CG_CVAR( cg_railTrailRadius, "cg_railTrailRadius", "0", CVAR_ARCHIVE  )

--- a/code/cgame/cg_cvar.h
+++ b/code/cgame/cg_cvar.h
@@ -39,6 +39,8 @@ CG_CVAR( cg_crosshairY, "cg_crosshairY", "0", CVAR_ARCHIVE )
 CG_CVAR( cg_brassTime, "cg_brassTime", "2500", CVAR_ARCHIVE )
 CG_CVAR( cg_simpleItems, "cg_simpleItems", "0", CVAR_ARCHIVE )
 CG_CVAR( cg_addMarks, "cg_marks", "1", CVAR_ARCHIVE )
+// Note that ~290 corresponds to a free fall with no bounce from player height.
+CG_CVAR( cg_bounceMarksMinImpactSpeed, "cg_bounceMarksMinImpactSpeed", "350", CVAR_ARCHIVE )
 CG_CVAR( cg_lagometer, "cg_lagometer", "1", CVAR_ARCHIVE )
 CG_CVAR( cg_railTrailTime, "cg_railTrailTime", "400", CVAR_ARCHIVE  )
 CG_CVAR( cg_railTrailRadius, "cg_railTrailRadius", "0", CVAR_ARCHIVE  )

--- a/code/cgame/cg_localents.c
+++ b/code/cgame/cg_localents.c
@@ -149,9 +149,11 @@ void CG_FragmentBounceMark( localEntity_t *le, trace_t *trace ) {
 	}
 
 
-	// don't allow a fragment to make multiple marks, or they
-	// pile up while settling
-	le->leMarkType = LEMT_NONE;
+	// This is no longer needed, because we now decide whether to leave a mark
+	// purely based on impact velocity.
+	// // don't allow a fragment to make multiple marks, or they
+	// // pile up while settling
+	// le->leMarkType = LEMT_NONE;
 }
 
 /*
@@ -188,9 +190,11 @@ void CG_FragmentBounceSound( localEntity_t *le, trace_t *trace ) {
 /*
 ================
 CG_ReflectVelocity
+
+Modifies velocity of `le` and writes the difference to `velocityDifference`
 ================
 */
-void CG_ReflectVelocity( localEntity_t *le, trace_t *trace ) {
+void CG_ReflectVelocity( localEntity_t *le, trace_t *trace, vec3_t velocityDifference ) {
 	vec3_t	velocity;
 	float	dot;
 	int		hitTime;
@@ -202,6 +206,10 @@ void CG_ReflectVelocity( localEntity_t *le, trace_t *trace ) {
 	VectorMA( velocity, -2*dot, trace->plane.normal, le->pos.trDelta );
 
 	VectorScale( le->pos.trDelta, le->bounceFactor, le->pos.trDelta );
+
+	if (velocityDifference) {
+		VectorSubtract( le->pos.trDelta, velocity, velocityDifference );
+	}
 
 	VectorCopy( trace->endpos, le->pos.trBase );
 	le->pos.trTime = cg.time;
@@ -223,7 +231,7 @@ CG_AddFragment
 ================
 */
 static void CG_AddFragment( localEntity_t *le ) {
-	vec3_t	newOrigin;
+	vec3_t	newOrigin, impactVelocityDiff;
 	trace_t	trace;
 
 	if ( le->pos.trType == TR_STATIONARY ) {
@@ -283,14 +291,16 @@ static void CG_AddFragment( localEntity_t *le ) {
 		return;
 	}
 
-	// leave a mark
-	CG_FragmentBounceMark( le, &trace );
+	// reflect the velocity on the trace plane
+	CG_ReflectVelocity( le, &trace, impactVelocityDiff );
+
+	if ( VectorLengthSquared( impactVelocityDiff ) >= Square( cg_bounceMarksMinImpactSpeed.value ) ) {
+		// leave a mark
+		CG_FragmentBounceMark( le, &trace );
+	}
 
 	// do a bouncy sound
 	CG_FragmentBounceSound( le, &trace );
-
-	// reflect the velocity on the trace plane
-	CG_ReflectVelocity( le, &trace );
 
 	trap_R_AddRefEntityToScene( &le->refEntity );
 }

--- a/code/cgame/cg_localents.c
+++ b/code/cgame/cg_localents.c
@@ -181,9 +181,11 @@ void CG_FragmentBounceSound( localEntity_t *le, trace_t *trace ) {
 
 	}
 
-	// don't allow a fragment to make multiple bounce sounds,
-	// or it gets too noisy as they settle
-	le->leBounceSoundType = LEBS_NONE;
+	// This is no longer needed, because we now decide whether to play a sound
+	// purely based on impact velocity.
+	// // don't allow a fragment to make multiple bounce sounds,
+	// // or it gets too noisy as they settle
+	// le->leBounceSoundType = LEBS_NONE;
 }
 
 
@@ -299,8 +301,10 @@ static void CG_AddFragment( localEntity_t *le ) {
 		CG_FragmentBounceMark( le, &trace );
 	}
 
-	// do a bouncy sound
-	CG_FragmentBounceSound( le, &trace );
+	if ( VectorLengthSquared( impactVelocityDiff ) >= Square( cg_bounceSoundMinImpactSpeed.value ) ) {
+		// do a bouncy sound
+		CG_FragmentBounceSound( le, &trace );
+	}
 
 	trap_R_AddRefEntityToScene( &le->refEntity );
 }


### PR DESCRIPTION
It's more "physically accurate" to decide whether to leave a mark
and play a sound based on velocity.
This allows gibs to leave multiple marks and play the sound,
should they keep high velocity after the first impact.

Also keep leaving the blood trail even if the gib already hit something.

TODO:
- [ ] Update README.