### PR TITLE
fix: don't spawn powerups immediately

### DIFF
--- a/code/game/g_items.c
+++ b/code/game/g_items.c
@@ -758,6 +758,18 @@ void FinishSpawningItem( gentity_t *ent ) {
 		return;
 	}
 
+	// powerups don't spawn in for a while
+	if ( ent->item->giType == IT_POWERUP ) {
+		int	respawn;
+
+		respawn = SPAWN_POWERUP + crandom() * 15 * 1000;
+		ent->s.eFlags |= EF_NODRAW;
+		ent->r.contents = 0;
+		ent->nextthink = level.time + respawn;
+		ent->think = RespawnItem;
+		return;
+	}
+
 	trap_LinkEntity( ent );
 }
 


### PR DESCRIPTION
Closes #8.

The bug has been introduced in
2c65e577e393a8151c74a84130300ff13a9617cc.
This commit basically brings back the code that was removed
as part of that one.

The intent of that commit was to spawn the powerups immediately
for warmup, but then spawn them as usual when the warmup ends,
in `G_WarmupEnd`.
However, it's not always that we get to execute `G_WarmupEnd`.
Namely, it doesn't get executed when `g_warmup 0`
or in single player matches.

The downside is, of course, that we no longer spawn the powerups
for warmup immediately.

So let's simply revert that change until a better solution is found.

I have tested this
- in single player mode
- with `g_warmup 10`
- with `g_warmup 0`