### PR TITLE
fix: shotgun not applying knockback on frag (v2)

### DIFF
--- a/code/game/g_active.c
+++ b/code/game/g_active.c
@@ -1154,6 +1154,12 @@ void ClientEndFrame( gentity_t *ent ) {
 
 	client->ps.stats[STAT_HEALTH] = ent->health;	// FIXME: get rid of ent->health...
 
+	// This is not present in the original game code,
+	// see comments about `FL_NO_KNOCKBACK` in `g_combat`.
+	if ( client->ps.pm_type & PM_DEAD ) {
+		ent->flags |= FL_NO_KNOCKBACK;
+	}
+
 	G_SetClientSound( ent );
 
 	// set the latest info

--- a/code/game/g_combat.c
+++ b/code/game/g_combat.c
@@ -1064,8 +1064,30 @@ void G_Damage( gentity_t *targ, gentity_t *inflictor, gentity_t *attacker,
 		}
 			
 		if ( targ->health <= 0 ) {
-			if ( client )
-				targ->flags |= FL_NO_KNOCKBACK;
+			// In the original code we used to set `FL_NO_KNOCKBACK` here.
+			// However, that made it so that when fragging with the shotgun,
+			// the dead body does not gain momentum (knockback)
+			// from the pellets that come after the pellet
+			// that made the health go below 0.
+			// That resulted in the dead body not getting pushed
+			// as far as it should have been, and, most importantly,
+			// the gibs not getting enough momentum. See
+			// https://github.com/ec-/baseq3a/pull/53.
+			//
+			// Now we set the `FL_NO_KNOCKBACK` flag inside of `ClientEndFrame`,
+			// which is ran after all the pellets of the shotgun shot
+			// have done their thing,
+			// i.e. `FL_NO_KNOCKBACK` takes effect only on the next frame.
+			//
+			// Note that if the body gets gibbed then
+			// it will still stop absorbing pellets,
+			// i.e. this fix only adds at most `GIB_HEALTH` worth of knockback.
+			//
+			// This issiue is similar to
+			// https://github.com/ioquake/ioq3/issues/794.
+			//
+			// if ( client )
+			// 	targ->flags |= FL_NO_KNOCKBACK;
 
 			if (targ->health < -999)
 				targ->health = -999;


### PR DESCRIPTION
Supersedes #54.
Thanks @LegendaryGuard for the guidance!

This fix is primarily aimed towards improving #53, but it is also useful on its own.

This is me on #53 and with `cg_gibsMaxRandomVelocity 0` shooting at a low HP enemy, before the fix, then after:

https://github.com/user-attachments/assets/1b7bc5f6-3205-4616-9f99-66f2b3051329

https://github.com/user-attachments/assets/a46ec5a2-6999-45cf-b908-db1a49d74d0a

