### PR TITLE
chore: add no-proprietary build option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest]
         arch: [x86, x86_64]
+        bundle_assets: [free, proprietary]
         include:
           # Windows
           - os: windows-latest
@@ -23,6 +24,11 @@ jobs:
           - os: ubuntu-latest
             arch: x86_64
             platform: linux
+        exclude:
+          - bundle_assets: free
+            os: windows-latest
+          - bundle_assets: free
+            arch: x86
 
     steps:
     - uses: actions/checkout@v4
@@ -44,17 +50,17 @@ jobs:
         else
           # Linux build steps
           cd build/linux
-          make -j8 release ARCH="${{ matrix.arch }}"
-          make -j8 debug ARCH="${{ matrix.arch }}"
+          make -j8 release ARCH="${{ matrix.arch }}" BUNDLE_ASSETS="${{ matrix.bundle_assets }}"
+          make -j8 debug ARCH="${{ matrix.arch }}" BUNDLE_ASSETS="${{ matrix.bundle_assets }}"
 
           # compiles DLL behaving like MINGW:
-          make -j8 release PLATFORM=mingw64 ARCH="${{ matrix.arch }}"
-          make -j8 debug PLATFORM=mingw64 ARCH="${{ matrix.arch }}"
+          make -j8 release PLATFORM=mingw64 ARCH="${{ matrix.arch }}" BUNDLE_ASSETS="${{ matrix.bundle_assets }}"
+          make -j8 debug PLATFORM=mingw64 ARCH="${{ matrix.arch }}" BUNDLE_ASSETS="${{ matrix.bundle_assets }}"
 
           # compiling QVMs
           cd ../../build/linux-qvm
           sudo chmod 777 tools/* # make all of them executable
-          make
+          make BUNDLE_ASSETS="${{ matrix.bundle_assets }}"
         fi
       env:
         ARCHIVE: 1
@@ -64,14 +70,14 @@ jobs:
       if: ${{ matrix.os != 'windows-latest' && matrix.arch != 'x86' }}
       uses: actions/upload-artifact@v4
       with:
-        name: QVMs
+        name: QVMs-${{ matrix.bundle_assets }}
         path: |
           build/linux-qvm/*.pk3
         if-no-files-found: error
         retention-days: 5
 
     - name: Store Linux ${{ matrix.arch }} .so artifacts
-      if: ${{ matrix.os != 'windows-latest' }}
+      if: ${{ matrix.os != 'windows-latest' && matrix.bundle_assets != 'free' }}
       uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.platform }}-${{ matrix.arch }}
@@ -82,7 +88,7 @@ jobs:
         retention-days: 5
 
     - name: Store Windows ${{ matrix.arch }} DLL artifacts (compiled on Linux)
-      if: ${{ matrix.os != 'windows-latest' }}
+      if: ${{ matrix.os != 'windows-latest' && matrix.bundle_assets != 'free' }}
       uses: actions/upload-artifact@v4
       with:
         name: windows-${{ matrix.arch }}

--- a/build/linux-qvm/Makefile
+++ b/build/linux-qvm/Makefile
@@ -12,8 +12,18 @@ dirs:
 
 .PHONY: all dirs
 
+ifndef BUNDLE_ASSETS
+	BUNDLE_ASSETS=proprietary
+endif
+export BUNDLE_ASSETS
+
 $(PK3): vm/qagame.qvm vm/cgame.qvm vm/ui.qvm
+ifneq ($(BUNDLE_ASSETS),free)
 	$(7Z) $@ vm/*.qvm vm/*.jts ../../assets/*
+else
+	$(7Z) $@ vm/*.qvm vm/*.jts ../../assets/menu ../../assets/scripts
+endif
+
 
 cc = cd vm/$1 && $(Q3LCC) $2 -o $(notdir $@).tmp ../../$< && mv $(notdir $@).tmp $(notdir $@)
 qa_cc = $(call cc,game,$(QA_CFLAGS))

--- a/build/linux/Makefile
+++ b/build/linux/Makefile
@@ -70,6 +70,11 @@ else
 endif
 export CROSS_COMPILING
 
+ifndef BUNDLE_ASSETS
+  BUNDLE_ASSETS=proprietary
+endif
+export BUNDLE_ASSETS
+
 #ifndef MOD_CFLAGS
 #MOD_CFLAGS= -std=c99
 #endif
@@ -210,6 +215,12 @@ endif
 
 ifdef DEFAULT_BASEDIR
   BASE_CFLAGS += -DDEFAULT_BASEDIR=\\\"$(DEFAULT_BASEDIR)\\\"
+endif
+
+# Otherwise we can't include the fonts and we cannot USE_NEW_FONT_RENDERER
+# because it relies on those fonts.
+ifneq ($(BUNDLE_ASSETS),free)
+  CFLAGS += -DUSE_NEW_FONT_RENDERER
 endif
 
 ifeq ($(NO_STRIP),1)

--- a/build/win32-qvm/compile.bat
+++ b/build/win32-qvm/compile.bat
@@ -290,6 +290,7 @@ copy vm\cgame\cgame.jts vm
 %tooldir%7za.exe a -tzip -mx=9 -mpass=8 -mfb=255 -- %pk3% vm\*.*
 rem rmdir /S /Q vm
 
+rem TODO respect `BUNDLE_ASSETS` var, see Linux build.
 cd ..\..\assets
 @if errorlevel 1 goto quit
 %tooldir%7za.exe a -tzip -mx=9 -mpass=8 -mfb=255 -r -- %pk3% *.*

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -1234,8 +1234,6 @@ void CG_DrawRect( float x, float y, float width, float height, float size, const
 void CG_DrawSides(float x, float y, float w, float h, float size);
 void CG_DrawTopBottom(float x, float y, float w, float h, float size);
 
-#define USE_NEW_FONT_RENDERER
-
 // flags for CG_DrawString
 enum {
 	DS_SHADOW      = 0x1,


### PR DESCRIPTION
The models icons and fonts don't seem to have been released under a free license.
Let's be making a build without those technically proprietary assets.

I have tested the "free" build, it works fine. 

TODO:
- [ ] Document this, maybe in README.
  - [ ] Document that `cg_hitSounds` doesn't work in the free build (it's always the same sound).
  - [ ] That there are no high-quality assets in the free version.
- [ ] Fix `-DUSE_NEW_FONT_RENDERER` not being respected in "proprietary" build. I am not sure where I need to pass this to make it work.