### PR TITLE
feat: add "Change Map" menu item

### DIFF
--- a/code/q3_ui/ui_ingame.c
+++ b/code/q3_ui/ui_ingame.c
@@ -26,6 +26,8 @@ INGAME MENU
 #define ID_QUIT					17
 #define ID_RESUME				18
 #define ID_TEAMORDERS			19
+// https://github.com/clover-moe/mint-arena/pull/7
+#define ID_CREATE				20
 
 
 typedef struct {
@@ -37,6 +39,7 @@ typedef struct {
 	menutext_s		server;
 	menutext_s		leave;
 	menutext_s		restart;
+	menutext_s		startnew;
 	menutext_s		addbots;
 	menutext_s		removebots;
 	menutext_s		teamorders;
@@ -103,6 +106,10 @@ void InGame_Event( void *ptr, int notification ) {
 		UI_ConfirmMenu( "RESTART ARENA?", (voidfunc_f)0, InGame_RestartAction );
 		break;
 
+	case ID_CREATE:
+		UI_StartServerMenu( qtrue );
+		break;
+
 	case ID_QUIT:
 		UI_ConfirmMenu( "EXIT GAME?",  (voidfunc_f)0, InGame_QuitAction );
 		break;
@@ -154,7 +161,7 @@ void InGame_MenuInit( void ) {
 	s_ingame.frame.generic.x			= 320-233;//142;
 	s_ingame.frame.generic.y			= 240-166;//118;
 	s_ingame.frame.width				= 466;//359;
-	s_ingame.frame.height				= 332;//256;
+	s_ingame.frame.height				= 356;//256;
 
 	//y = 96;
 	y = 88;
@@ -248,6 +255,22 @@ void InGame_MenuInit( void ) {
 	s_ingame.server.color				= color_red;
 	s_ingame.server.style				= UI_CENTER|UI_SMALLFONT;
 
+
+	y += INGAME_MENU_VERTICAL_SPACING;
+	s_ingame.startnew.generic.type			= MTYPE_PTEXT;
+	s_ingame.startnew.generic.flags			= QMF_CENTER_JUSTIFY|QMF_PULSEIFFOCUS;
+	s_ingame.startnew.generic.x				= 320;
+	s_ingame.startnew.generic.y				= y;
+	s_ingame.startnew.generic.id			= ID_CREATE;
+	s_ingame.startnew.generic.callback		= InGame_Event; 
+	s_ingame.startnew.string				= "CHANGE MAP";
+	s_ingame.startnew.color					= color_red;
+	s_ingame.startnew.style					= UI_CENTER|UI_SMALLFONT;
+	if( !trap_Cvar_VariableValue( "sv_running" ) ) {
+		s_ingame.startnew.generic.flags |= QMF_GRAYED;
+	}
+
+
 	y += INGAME_MENU_VERTICAL_SPACING;
 	s_ingame.restart.generic.type		= MTYPE_PTEXT;
 	s_ingame.restart.generic.flags		= QMF_CENTER_JUSTIFY|QMF_PULSEIFFOCUS;
@@ -303,6 +326,7 @@ void InGame_MenuInit( void ) {
 	Menu_AddItem( &s_ingame.menu, &s_ingame.setup );
 	Menu_AddItem( &s_ingame.menu, &s_ingame.server );
 	Menu_AddItem( &s_ingame.menu, &s_ingame.restart );
+	Menu_AddItem( &s_ingame.menu, &s_ingame.startnew );
 	Menu_AddItem( &s_ingame.menu, &s_ingame.resume );
 	Menu_AddItem( &s_ingame.menu, &s_ingame.leave );
 	Menu_AddItem( &s_ingame.menu, &s_ingame.quit );


### PR DESCRIPTION
See the original MR in another repo:
https://github.com/clover-moe/mint-arena/pull/7.

<img width="512" alt="image" src="https://github.com/user-attachments/assets/e6a11225-286e-464e-80e3-d7612d4bc26d" />
<img width="512" alt="image" src="https://github.com/user-attachments/assets/4dc38df3-8f05-44d3-9c77-3e168b01c21d" />

This allows you to change the map without restarting the server and making everyone reconnect.
