### PR TITLE
Replace STAT_DEAD_YAW logic to player_state->damagePitch and player_state->damageYaw, and preserve enum padding for demo netcode by renaming as STAT_UNUSED_INDEX

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Unofficial Quake III Arena gamecode patch
  * fixed shotgun not gibbing unless aiming at the feet
  * fixed server browser + faster scanning
  * fixed grappling hook muzzle position visuals
+ * replaced STAT_DEAD_YAW logic to player_state->damagePitch and player_state->damageYaw to sum the result, now it's renamed as STAT_UNUSED_INDEX and it can be reused even if you want.
  * new demo UI (subfolders,filtering,sorting)
  * updated serverinfo UI
  * map rotation system

--- a/code/cgame/cg_view.c
+++ b/code/cgame/cg_view.c
@@ -216,8 +216,9 @@ static void CG_OffsetThirdPersonView( void ) {
 
 	// if dead, look at killer
 	if ( cg.predictedPlayerState.stats[STAT_HEALTH] <= 0 ) {
-		focusAngles[YAW] = cg.predictedPlayerState.stats[STAT_DEAD_YAW];
-		cg.refdefViewAngles[YAW] = cg.predictedPlayerState.stats[STAT_DEAD_YAW];
+		int totalYaw = cg.predictedPlayerState.damageYaw + cg.predictedPlayerState.damagePitch;
+		focusAngles[YAW] = totalYaw;
+		cg.refdefViewAngles[YAW] = totalYaw;
 	}
 
 	if ( focusAngles[PITCH] > 45 ) {
@@ -311,7 +312,7 @@ static void CG_OffsetFirstPersonView( void ) {
 	if ( cg.snap->ps.stats[STAT_HEALTH] <= 0 ) {
 		angles[ROLL] = 40;
 		angles[PITCH] = -15;
-		angles[YAW] = cg.snap->ps.stats[STAT_DEAD_YAW];
+		angles[YAW] = cg.snap->ps.damageYaw + cg.snap->ps.damagePitch;
 		origin[2] += cg.predictedPlayerState.viewheight;
 		return;
 	}

--- a/code/game/bg_public.h
+++ b/code/game/bg_public.h
@@ -196,7 +196,7 @@ typedef enum {
 #endif
 	STAT_WEAPONS,					// 16 bit fields
 	STAT_ARMOR,				
-	STAT_DEAD_YAW,					// look this direction when dead (FIXME: get rid of?)
+	STAT_UNUSED_INDEX,				// unused stat index (before: STAT_DEAD_YAW)
 	STAT_CLIENTS_READY,				// bit mask of clients wishing to exit the intermission (FIXME: configstring?)
 	STAT_MAX_HEALTH					// health / armor limit, changable by handicap
 } statIndex_t;

--- a/code/game/g_combat.c
+++ b/code/game/g_combat.c
@@ -202,17 +202,31 @@ LookAtKiller
 */
 void LookAtKiller( gentity_t *self, gentity_t *inflictor, gentity_t *attacker ) {
 	vec3_t		dir;
+	float		killerYaw = self->s.angles[YAW];
 
 	if ( attacker && attacker != self ) {
 		VectorSubtract (attacker->s.pos.trBase, self->s.pos.trBase, dir);
 	} else if ( inflictor && inflictor != self ) {
 		VectorSubtract (inflictor->s.pos.trBase, self->s.pos.trBase, dir);
 	} else {
-		self->client->ps.stats[STAT_DEAD_YAW] = self->s.angles[YAW];
+		if ( killerYaw > 255 ) {
+			self->client->ps.damageYaw = 255;
+			self->client->ps.damagePitch = (int)( killerYaw - 255 ); 
+		} else {
+			self->client->ps.damageYaw = (int)killerYaw;
+			self->client->ps.damagePitch = 0;
+		}
 		return;
 	}
 
-	self->client->ps.stats[STAT_DEAD_YAW] = vectoyaw ( dir );
+	killerYaw = vectoyaw ( dir );
+	if ( killerYaw > 255 ) {
+		self->client->ps.damageYaw = 255;
+		self->client->ps.damagePitch = (int)( killerYaw - 255 ); 
+	} else {
+		self->client->ps.damageYaw = (int)killerYaw;
+		self->client->ps.damagePitch = 0;
+	}
 }
 
 /*


### PR DESCRIPTION
Uses `player_state->damageYaw` does the same behavior and can be reused for these situations.
That could fix a `FIXME` task in `STAT_DEAD_YAW` enum from id Software, which was left since the first Q3 version release.

Tested and works.
Moreover, this `STAT_` slot can be reused, it isn't removed because it must retain the enum value for demo netcode safeness.

EDIT: 
Uses `ps->damagePitch` and `ps->damageYaw` to get the correct result, so that avoids 8 bits value issues.