### PR TITLE
Remove FIXME comments in STATs. No worth fixing for Quake 3 vanilla, breaks demo and pseudo-netcode

### DIFF
--- a/code/game/bg_public.h
+++ b/code/game/bg_public.h
@@ -196,8 +196,8 @@ typedef enum {
 #endif
 	STAT_WEAPONS,					// 16 bit fields
 	STAT_ARMOR,				
-	STAT_DEAD_YAW,					// look this direction when dead (FIXME: get rid of?)
-	STAT_CLIENTS_READY,				// bit mask of clients wishing to exit the intermission (FIXME: configstring?)
+	STAT_DEAD_YAW,					// look this direction when dead
+	STAT_CLIENTS_READY,				// bit mask of clients wishing to exit the intermission
 	STAT_MAX_HEALTH					// health / armor limit, changable by handicap
 } statIndex_t;
 


### PR DESCRIPTION
Nevermind
~~@ensiform is right: https://github.com/ec-/baseq3a/pull/69#issuecomment-3969572775~~

~~No matter how many times that effort is made, anyway, breaks demo and pseudo-netcode for Q3 vanilla.
That has already been tested: https://github.com/ec-/baseq3a/pull/69#issuecomment-4138494290~~

~~But for modders of other games, it's interesting replace/save this STAT slot in their own mods. To do it, just look at that commit I made previously: https://github.com/ec-/baseq3a/pull/69/changes/a0702c23562726c57181b777a4057bfcb96ee947~~

~~If you agree with the PR, do it. Otherwise, feel free to close it.
I don't care if that doesn't merge. But it might be recommended for anyone to not try to fix that and avoid losing time on it.~~