### PR TITLE
Fix: properly check for item disable status against segfault

### DIFF
--- a/code/game/g_items.c
+++ b/code/game/g_items.c
@@ -411,7 +411,6 @@ void RespawnItem( gentity_t *ent ) {
 	// randomly select from teamed entities
 	if ( ent->team ) {
 		gentity_t *master;
-		gitem_t *item;
 		int	count;
 		int choice;
 
@@ -422,15 +421,13 @@ void RespawnItem( gentity_t *ent ) {
 		master = ent->teammaster;
 
 		for ( count = 0, ent = master; ent; ent = ent->teamchain ) {
-			item = ent->item;
+			// Skip disabled items
+			if ( ent->tag == TAG_DONTSPAWN ) {
+				continue;
+			}
 
 			// reset spawn timers on all teamed entities
 			ent->nextthink = 0;
-
-			// Some items could be disabled due to server settings
-			if ( !item || G_ItemDisabled(item) ) {
-				continue;
-			}
 
 			count++;
 		}
@@ -443,10 +440,8 @@ void RespawnItem( gentity_t *ent ) {
 		choice = rand() % count;
 
 		for ( count = 0, ent = master; ent && count < choice; ent = ent->teamchain ) {
-			item = ent->item;
-
-			// Skip prohibited items
-			if ( !item || G_ItemDisabled(item) ) {
+			// Skip disabled items
+			if ( ent->tag == TAG_DONTSPAWN ) {
 				continue;
 			}
 
@@ -454,7 +449,7 @@ void RespawnItem( gentity_t *ent ) {
 		}
 	}
 
-	if ( !ent ) {
+	if ( !ent || ent->tag == TAG_DONTSPAWN ) {
 		return;
 	}
 
@@ -963,14 +958,12 @@ void G_SpawnItem( gentity_t *ent, gitem_t *item ) {
 
 	RegisterItem( item );
 
-	// Should not be nullish if item is disabled
-	ent->item = item;
-
 	if ( G_ItemDisabled( item ) ) {
 		ent->tag = TAG_DONTSPAWN;
 		return;
 	}
 
+	ent->item = item;
 	// some movers spawn on the second frame, so delay item
 	// spawns until the third frame so they can ride trains
 	ent->nextthink = level.time + FRAMETIME * 2;

--- a/code/game/g_items.c
+++ b/code/game/g_items.c
@@ -385,6 +385,19 @@ int Pickup_Armor( gentity_t *ent, gentity_t *other ) {
 //======================================================================
 
 /*
+============
+G_ItemDisabled
+============
+*/
+int G_ItemDisabled( gitem_t *item ) {
+
+	char name[128];
+
+	Com_sprintf(name, sizeof(name), "disable_%s", item->classname);
+	return trap_Cvar_VariableIntegerValue( name );
+}
+
+/*
 ===============
 RespawnItem
 ===============
@@ -398,6 +411,7 @@ void RespawnItem( gentity_t *ent ) {
 	// randomly select from teamed entities
 	if ( ent->team ) {
 		gentity_t *master;
+		gitem_t *item;
 		int	count;
 		int choice;
 
@@ -407,15 +421,37 @@ void RespawnItem( gentity_t *ent ) {
 
 		master = ent->teammaster;
 
-		for ( count = 0, ent = master; ent; ent = ent->teamchain, count++ ) {
+		for ( count = 0, ent = master; ent; ent = ent->teamchain ) {
+			item = ent->item;
+
 			// reset spawn timers on all teamed entities
 			ent->nextthink = 0;
+
+			// Some items could be disabled due to server settings
+			if ( !item || G_ItemDisabled(item) ) {
+				continue;
+			}
+
+			count++;
+		}
+
+		// No valid items to spawn
+		if ( count == 0 ) {
+			return;
 		}
 
 		choice = rand() % count;
 
-		for ( count = 0, ent = master; ent && count < choice; ent = ent->teamchain, count++ )
-			;
+		for ( count = 0, ent = master; ent && count < choice; ent = ent->teamchain ) {
+			item = ent->item;
+
+			// Skip prohibited items
+			if ( !item || G_ItemDisabled(item) ) {
+				continue;
+			}
+
+			count++;
+		}
 	}
 
 	if ( !ent ) {
@@ -912,19 +948,6 @@ void SaveRegisteredItems( void ) {
 
 /*
 ============
-G_ItemDisabled
-============
-*/
-int G_ItemDisabled( gitem_t *item ) {
-
-	char name[128];
-
-	Com_sprintf(name, sizeof(name), "disable_%s", item->classname);
-	return trap_Cvar_VariableIntegerValue( name );
-}
-
-/*
-============
 G_SpawnItem
 
 Sets the clipping size and plants the object on the floor.
@@ -940,12 +963,14 @@ void G_SpawnItem( gentity_t *ent, gitem_t *item ) {
 
 	RegisterItem( item );
 
+	// Should not be nullish if item is disabled
+	ent->item = item;
+
 	if ( G_ItemDisabled( item ) ) {
 		ent->tag = TAG_DONTSPAWN;
 		return;
 	}
 
-	ent->item = item;
 	// some movers spawn on the second frame, so delay item
 	// spawns until the third frame so they can ride trains
 	ent->nextthink = level.time + FRAMETIME * 2;


### PR DESCRIPTION
### Trivia
I have a teamplay server with `g_gametype 3` and some items disabled through `disable_<item>` cvars. I noticed, that on some maps my server was randomly crashing with `SIGSEGV` ( I'm using native libraries ).

This is really rare bug. I found only one way to reproduce it with guaranteed result.

### Reliable way to reproduce

Build native libraries and copy them into **baseq3**. Download map _"battleforged"_ ( [battleforged.zip](https://github.com/user-attachments/files/27374001/battleforged.zip) ) and make a simple config, which disables a bunch of items and adds some bots:

<details>
<summary>disable.cfg</summary>

```cfg
set disable_weapon_gauntlet 1
set disable_weapon_shotgun 1
set disable_weapon_machinegun 1
set disable_weapon_grenadelauncher 1
set disable_weapon_rocketlauncher 1
set disable_weapon_lightning 1
set disable_weapon_railgun 1
set disable_weapon_plasmagun 1
set disable_weapon_bfg 1
set disable_ammo_shells 1
set disable_ammo_bullets 1
set disable_ammo_grenades 1
set disable_ammo_cells 1
set disable_ammo_lightning 1
set disable_ammo_rockets 1
set disable_ammo_slugs 1
set disable_ammo_bfg 1
set disable_item_armor_shard 1
set disable_item_armor_combat 1
set disable_item_armor_body 1
set disable_item_health_small 1
set disable_item_health 1
set disable_item_health_large 1
set disable_item_health_mega 1
set disable_item_quad 1

addbot Xaero 5
addbot Xaero 5
addbot Xaero 5
addbot Xaero 5
addbot Xaero 5
addbot Xaero 5
addbot Xaero 5
```
</details>

Start a server through command line:
```bash
./q3ded +set sv_pure 0 +set vm_game 0 +devmap battleforged +set g_gametype 3 +exec disable.cfg
```

After connecting to a server, restart the map through `map_restart` and wait, untill it crashes. I sped up game with `timescale 100` and `sv_fps 250`, so I can observe crash after about 10 seconds of watching bots playing.

### Why it's crashing

When an item is disabled through a cvar, the `item` field of `gentity_t` is left `NULL`. `RespawnItem` wants to respawn an item and tries to dereference nullish `ent->item`, which leads to segmentation violation. This is also true for _"teamed"_ items, where a random picked item from the _"team"_ could be disabled, thus have nullish `ent->item`.