### PR TITLE
fix: win condition on frag + suicide with splash

### DIFF
--- a/code/game/g_combat.c
+++ b/code/game/g_combat.c
@@ -1185,7 +1185,7 @@ qboolean G_RadiusDamage ( gentity_t *self, vec3_t origin, gentity_t *attacker, f
 	vec3_t		mins, maxs;
 	vec3_t		v;
 	vec3_t		dir;
-	int			i, e;
+	int			i, e, swapInd;
 	qboolean	hitClient = qfalse;
 
 	if ( radius < 1 ) {
@@ -1198,6 +1198,41 @@ qboolean G_RadiusDamage ( gentity_t *self, vec3_t origin, gentity_t *attacker, f
 	}
 
 	numListedEntities = trap_EntitiesInBox( mins, maxs, entityList, MAX_GENTITIES );
+
+	// Put the attacker and their team members at the beginning of the list
+	// so that we damage them first, to make for more deterministic behavior.
+	// Otherwise if 1 frag left for the attacker and they both frag and suicide
+	// with this missile then they may or may not win,
+	// depending on the order returned from `trap_EntitiesInBox`,
+	// which is not defined (or at least is not relevant to us here).
+	//
+	// Note, however, that during sudden death this situation will result
+	// in the attacker's team losing.
+	//
+	// An alternative would be to sort by distance,
+	// which is what e.g. ETLegacy does:
+	// https://github.com/etlegacy/etlegacy/blob/764ffc00a953e59aaf435272d004c49a89710309/src/game/g_combat.c#L2373
+	for ( e = 0, swapInd = 0 ; e < numListedEntities ; e++ ) {
+		ent = &g_entities[entityList[ e ]];
+		if ( ent == attacker || OnSameTeam( ent, attacker ) ) {
+			const int temp = entityList[ e ];
+			entityList[ e ] = entityList[ swapInd ];
+			entityList[ swapInd ] = temp;
+
+			swapInd++;
+		}
+	}
+	// For extra determinism, damage self before other team members.
+	for ( e = 0 ; e < numListedEntities ; e++ ) {
+		ent = &g_entities[entityList[ e ]];
+		if ( ent == attacker ) {
+			const int temp = entityList[ e ];
+			entityList[ e ] = entityList[ 0 ];
+			entityList[ 0 ] = temp;
+
+			break;
+		}
+	}
 
 	for ( e = 0 ; e < numListedEntities ; e++ ) {
 		ent = &g_entities[entityList[ e ]];


### PR DESCRIPTION
This is the inconsistent behavior in question:

https://github.com/user-attachments/assets/5f894b6a-1a5a-4911-b5f1-b2cbc1d7c217

Related:
- https://github.com/etlegacy/etlegacy/pull/2051.