### PR TITLE
fix: win condition on frag + suicide

### DIFF
--- a/code/game/g_local.h
+++ b/code/game/g_local.h
@@ -408,6 +408,12 @@ typedef struct {
 	int			numSpawnVarChars;
 	char		spawnVarChars[MAX_SPAWN_VARS_CHARS];
 
+#ifndef OLD_CHECK_EXIT_RULES
+	// `CheckExitRulesLater()` has been called, and we'll need to
+	// `CheckExitRules()` when we're done doing stuff.
+	qboolean	needToCheckExitRules;
+#endif
+
 	// intermission state
 	int			intermissionQueued;		// intermission was qualified, but
 										// wait INTERMISSION_DELAY_TIME before

--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -59,40 +59,55 @@ This must be the very first function compiled into the .q3vm file
 ================
 */
 DLLEXPORT intptr_t vmMain( int command, int arg0, int arg1, int arg2 ) {
+	int ret;
+
 	switch ( command ) {
 	case GAME_INIT:
 		G_InitGame( arg0, arg1, arg2 );
-		return 0;
+		ret = 0;
+		break;
 	case GAME_SHUTDOWN:
 		G_ShutdownGame( arg0 );
-		return 0;
+		ret = 0;
+		break;
 	case GAME_CLIENT_CONNECT:
-		return (intptr_t)ClientConnect( arg0, arg1, arg2 );
+		ret = (intptr_t)ClientConnect( arg0, arg1, arg2 );
+		break;
 	case GAME_CLIENT_THINK:
 		ClientThink( arg0 );
-		return 0;
+		ret = 0;
+		break;
 	case GAME_CLIENT_USERINFO_CHANGED:
 		ClientUserinfoChanged( arg0 );
-		return 0;
+		ret = 0;
+		break;
 	case GAME_CLIENT_DISCONNECT:
 		ClientDisconnect( arg0 );
-		return 0;
+		ret = 0;
+		break;
 	case GAME_CLIENT_BEGIN:
 		ClientBegin( arg0 );
-		return 0;
+		ret = 0;
+		break;
 	case GAME_CLIENT_COMMAND:
 		ClientCommand( arg0 );
-		return 0;
+		ret = 0;
+		break;
 	case GAME_RUN_FRAME:
 		G_RunFrame( arg0 );
-		return 0;
+		ret = 0;
+		break;
 	case GAME_CONSOLE_COMMAND:
-		return ConsoleCommand();
+		ret = ConsoleCommand();
+		break;
 	case BOTAI_START_FRAME:
-		return BotAIStartFrame( arg0 );
+		ret = BotAIStartFrame( arg0 );
+		break;
+	default:
+		ret = -1;
 	}
 
-	return -1;
+	return ret;
 }
 
 

--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -39,6 +39,9 @@ static void G_InitGame( int levelTime, int randomSeed, int restart );
 static void G_RunFrame( int levelTime );
 static void G_ShutdownGame( int restart );
 static void CheckExitRules( void );
+#ifndef OLD_CHECK_EXIT_RULES
+static void CheckExitRulesLater( void );
+#endif
 static void SendScoreboardMessageToAllClients( void );
 
 // extension interface
@@ -106,6 +109,43 @@ DLLEXPORT intptr_t vmMain( int command, int arg0, int arg1, int arg2 ) {
 	default:
 		ret = -1;
 	}
+
+#ifndef OLD_CHECK_EXIT_RULES
+	// In vanilla we did `CheckExitRules()` after each frag,
+	// which there can be multiple of when dealing with e.g. splash damage.
+	// And the order in which players get killed is not well-defined:
+	// e.g. for `G_RadiusDamage` and telefrag, kills get performed
+	// in the order returned from `trap_EntitiesInBox`;
+	// for the shotgun each pellet deals damage by itself,
+	// and the order is random;
+	// for the railgun the closest enemy gets damaged first.
+	// That resulted in inconsistent rules when there is one frag left
+	// and someone frags both a enemy and themself (or a teammate):
+	// if the enemy is processed first then the attacker wins.
+	// If a teammate is processed first then the game continues.
+	// Let's fix this by only doing `CheckExitRules()`
+	// when we're done processing the command.
+	//
+	// Note that this new behavior can result in e.g. two players
+	// hitting the frag limit at the same time.
+	// This can happen with missiles, which we run in `G_RunFrame()`.
+	// In such a case `ScoreIsTied()` will kick in, and the game will continue
+	// until the score gets untied, so this new behavior doesn't introduce
+	// a "multiple winners" situation.
+	//
+	// One might argue that in case of two missiles exploding on the same frame,
+	// the old behavoir is more fair, because `G_RunMissile()` is run
+	// in the order in which the missiles were created,
+	// so whoever shot first should win.
+	// However, this isn't entirely obviously fair,
+	// because two missiles can explode on the same frame
+	// even if they were shot a long time apart.
+	// For example, grenade launcher vs rocket launcher.
+	// In this case let's just tie the score.
+	if ( level.needToCheckExitRules ) {
+		CheckExitRules();
+	}
+#endif
 
 	return ret;
 }
@@ -871,7 +911,11 @@ void CalculateRanks( void ) {
 	}
 
 	// see if it is time to end the level
+#ifndef OLD_CHECK_EXIT_RULES
+	CheckExitRulesLater();
+#else
 	CheckExitRules();
+#endif
 
 	// if we are at the intermission, send the new info to everyone
 	if ( level.intermissiontime ) {
@@ -1338,6 +1382,10 @@ static void CheckExitRules( void ) {
  	int			i;
 	gclient_t	*cl;
 
+#ifndef OLD_CHECK_EXIT_RULES
+	level.needToCheckExitRules = qfalse;
+#endif
+
 	// if at the intermission, wait for all non-bots to
 	// signal ready, then go to next level
 	if ( level.intermissiontime ) {
@@ -1425,6 +1473,11 @@ static void CheckExitRules( void ) {
 		}
 	}
 }
+#ifndef OLD_CHECK_EXIT_RULES
+static void CheckExitRulesLater( void ) {
+	level.needToCheckExitRules = qtrue;
+}
+#endif
 
 
 static void ClearBodyQue( void ) {


### PR DESCRIPTION
This is the inconsistent behavior in question:

https://github.com/user-attachments/assets/5f894b6a-1a5a-4911-b5f1-b2cbc1d7c217

With the fix:

https://github.com/user-attachments/assets/f155c479-416f-410d-a3c4-733f0b93c695

And this is how we handle the "fragged each other at the same time" situation:

https://github.com/user-attachments/assets/a19942e0-8953-4253-b7d9-c519c2a15189

<details><summary>log</summary>

Reproducible with `bind Y "set g_speed 1; set bot_pause 0; +fire"`, and `com_maxfps 30; sv_fps 20`. (Another useful bind: `bind U "toggle bot_pause"`).

```log
]\toggle g_speed 320 1
Server: g_speed changed to 1
t=224450 fire_rocket, owner: Keel
t=224450 G_RunMissile 0, owner: Keel
t=224450 fire_rocket, owner: WofWca
t=224500 G_RunMissile 0, owner: Keel
t=224500 G_RunMissile 1, owner: WofWca
t=224550 G_RunMissile 0, owner: Keel
t=224550 G_RunMissile 1, owner: WofWca
t=224600 G_RunMissile 0, owner: Keel
t=224600 G_RunMissile 1, owner: WofWca
t=224650 G_RunMissile 0, owner: Keel
t=224650 G_RunMissile 1, owner: WofWca
t=224700 G_RunMissile 0, owner: Keel
t=224700 G_RunMissile 1, owner: WofWca
t=224750 G_RunMissile 0, owner: Keel
t=224750 G_RunMissile 1, owner: WofWca
WofWca^7 ate Keel^7's rocket
Keel^7 ate WofWca^7's rocket
]\stoprecord 
Stopped demo recording.
```

</details>

(if you're wondering about the "teams are tied" announcement:
it's not about this MR. It's also reproducible in vanilla,
if you shoot first a teammate then an enemy with the railgun).


Compared to #73
this is a more general and robust fix,
also affecting railgun, shotgun, direct missile hits,
and telefrags.
Basically this ensures that weapon behavior does not differ
depending on whether there is 1 frag left or not.
That is, a railgun kills two players if they're aligned,
a rocket kills everyone who's in splash radius, etc.

I actually started working on this before #73 got merged,
but unfortunately I didn't mark it as draft in time.
So when/if this MR gets merged, that one
is basically not needed anymore and can be reverted for simplicity.
Or maybe the consistency is nice anyway,
at least for the order of log messages,
so only the comment needs to be adjusted at least.

Note that `G_RunFrame` still calls `CheckExitRules()` directly,
which probably makes sense, to keep things as is there.

Related:
- https://github.com/etlegacy/etlegacy/pull/2051.
