### PR TITLE
perf: save bandwidth on dead bodies, CopyToBodyQue

### DIFF
--- a/code/game/g_client.c
+++ b/code/game/g_client.c
@@ -387,6 +387,14 @@ void CopyToBodyQue( gentity_t *ent ) {
 		break;
 	}
 
+	// Reset unused fields to 0 to save bandwidth (don't send their deltas).
+	// See `CG_PlayerAngles`.
+	body->s.eventParm = 0;
+	// Apos is not gonna change, so it's OK not to `TR_INTERPOLATE`.
+	body->s.apos.trType = TR_STATIONARY;
+	VectorClear( body->s.angles );
+	VectorClear( body->s.angles2 );
+
 	body->r.svFlags = ent->r.svFlags;
 	VectorCopy (ent->r.mins, body->r.mins);
 	VectorCopy (ent->r.maxs, body->r.maxs);


### PR DESCRIPTION
It's easy to test this with `set cl_shownet 2; set bot_pause 1`
and a single bot.

Below is the diff between vanilla and this commit.
As you can see, the "new" delta is smaller,
some fields (`angles`, etc) are omitted.

```diff
    22: #1 remove
-24: #64 pos.trBase[0]:392 pos.trBase[1]:1431 pos.trBase[2]:24 apos.trBase[1]:315 angles2[1]:1 еТуре:1 torsoAnim:1 legsAnim:1 groundEntityNum:1022 eFlags:1 clientNum:1 angles[1]:135 apos.trType:1 (340 bits)
-45: END OF MESSAGE
+24: #67 pos.trBase[0]:392 pos.trBase[1]:1431 pos.trBase[2]:24 ароs.trBase[1]:315 еТуре:1 torsoAnim:3 legsAnim:3 groundEntityNum:1022 eFlags:1 clientNum:1 (275 bits)
+41: END OF MESSAGE
```

- [x] Why draft? I want to test this for a bit more.
  So far things seem alright.
