### PR TITLE
Fix trap_BotFreeItemWeights() for qagame.qvm

### DIFF
--- a/code/game/g_syscalls.asm
+++ b/code/game/g_syscalls.asm
@@ -181,7 +181,7 @@ equ trap_BotAvoidGoalTime				-541
 equ trap_BotInitLevelItems				-542
 equ trap_BotUpdateEntityItems			-543
 equ trap_BotLoadItemWeights				-544
-equ trap_BotFreeItemWeights				-546
+equ trap_BotFreeItemWeights				-545
 equ trap_BotSaveGoalFuzzyLogic			-546
 equ trap_BotAllocGoalState				-547
 equ trap_BotFreeGoalState				-548


### PR DESCRIPTION
```c
equ trap_BotFreeItemWeights				-546
equ trap_BotSaveGoalFuzzyLogic			-546
```

Compiling qagame.qvm incorrectly mapped trap_BotFreeItemWeights() to the syscall for BOTLIB_AI_SAVE_GOAL_FUZZY_LOGIC. However this is not called by baseq3 or missionpack qagame.qvm so correcting it does not affect the built Quake 3 QVMs.

Reported by Tobias Kuehnhammer.