### PR TITLE
fix: make CD key UI prevalidation accept uppercase

### DIFF
--- a/code/q3_ui/ui_cdkey.c
+++ b/code/q3_ui/ui_cdkey.c
@@ -76,7 +76,7 @@ static int UI_CDKeyMenu_PreValidateKey( const char *key ) {
 	}
 
 	while( ( ch = *key++ ) ) {
-		switch( ch ) {
+		switch( tolower( ch ) ) {
 		case '2':
 		case '3':
 		case '7':


### PR DESCRIPTION
This issue is annoying since Steam provides an uppercase key.

Similar commit in ioquake3:
https://github.com/ioquake/ioq3/commit/b75bee106481f955898072010d30912facfbb36a
(https://github.com/ioquake/ioq3/pull/880).

The engine actually does a case-insensitive comparison:
https://github.com/ec-/Quake3e/blob/ed1064f80fda9cde2e7d33c2d5dce8f8166b12bd/code/qcommon/common.c#L3113-L3140.

I have tested this with the ioq3 engine.
Quake3e seems to have a bug where it doesn't write the CD key file.
