### PR TITLE
fix: show own blood in third person

### DIFF
--- a/code/cgame/cg_effects.c
+++ b/code/cgame/cg_effects.c
@@ -532,7 +532,7 @@ void CG_Bleed( const vec3_t origin, int entityNum ) {
 	ex->refEntity.customShader = cgs.media.bloodExplosionShader;
 
 	// don't show player's own blood in view
-	if ( entityNum == cg.snap->ps.clientNum ) {
+	if ( entityNum == cg.snap->ps.clientNum && !cg.renderingThirdPerson ) {
 		ex->refEntity.renderfx |= RF_THIRD_PERSON;
 	}
 }


### PR DESCRIPTION
Applies to:
- Lying dead on the ground and someone shooting at you
- `cg_thirdPerson 1`
